### PR TITLE
Updated chartist-js to v0.5.0

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,14 +1,14 @@
 Package.describe({
-  name: 'mfpierre:chartist-js',
+  name: 'slackcc:chartist-js',
   summary: 'Simple responsive charts',
   version: '1.1.0',
-  git: 'https://github.com/mfpierre/meteor-chartist-js'
+  git: 'https://github.com/slackcc/meteor-chartist-js'
 });
 
 Package.onUse(function(api) {
   api.versionsFrom('1.0');
   api.addFiles([
-    'chartist-js/libdist/chartist.min.js',
-    'chartist-js/libdist/chartist.min.css'
+    'chartist-js/dist/chartist.min.js',
+    'chartist-js/dist/chartist.min.css'
   ], 'client');
 });

--- a/package.js
+++ b/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  name: 'slackcc:meteor-chartist-js',
+  name: 'mfpierre:chartist-js',
   summary: 'Simple responsive charts',
   version: '1.2.0',
   git: 'https://github.com/slackcc/meteor-chartist-js'

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
-  name: 'slackcc:chartist-js',
+  name: 'slackcc:meteor-chartist-js',
   summary: 'Simple responsive charts',
-  version: '1.1.0',
+  version: '1.2.0',
   git: 'https://github.com/slackcc/meteor-chartist-js'
 });
 

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@ Package.describe({
   name: 'mfpierre:chartist-js',
   summary: 'Simple responsive charts',
   version: '1.2.0',
-  git: 'https://github.com/slackcc/meteor-chartist-js'
+  git: 'https://github.com/mfpierre/meteor-chartist-js'
 });
 
 Package.onUse(function(api) {


### PR DESCRIPTION
Hi there - I had a need for the latest version of chartist-js (v. 0.5.0) for meteor and forked off your branch.  I updated the submodule of chartist to the latest and modified the package.js to reflect the new directory structure that chartist is using (/dist instead of /libdist).  Would be great if this could be merged back into your branch!  First time I've done a pull request so hopefully doing it right :-)

Thanks - Chris
