### PR TITLE
Correctly export Chartist

### DIFF
--- a/after.js
+++ b/after.js
@@ -1,0 +1,1 @@
+Chartist = module.exports;

--- a/before.js
+++ b/before.js
@@ -1,0 +1,2 @@
+exports = {};
+module = {};

--- a/package.js
+++ b/package.js
@@ -7,8 +7,13 @@ Package.describe({
 
 Package.onUse(function(api) {
   api.versionsFrom('1.0');
+  api.use('fourseven:scss@3.4.1');
   api.addFiles([
-    'chartist-js/dist/chartist.min.js',
-    'chartist-js/dist/chartist.min.css'
+    'before.js',
+    'chartist-js/dist/chartist.js',
+    'chartist-js/dist/scss/settings/_chartist-settings.scss',
+    'chartist-js/dist/scss/chartist.scss',
+    'after.js'
   ], 'client');
+  api.export('Chartist');
 });


### PR DESCRIPTION
Before, `Chartist` was made a global symbol (added to `window`). This is not nice in Meteor packaging. This fixes it.
